### PR TITLE
Avoid infinite loop

### DIFF
--- a/pkg/nodeModules/tree.go
+++ b/pkg/nodeModules/tree.go
@@ -266,10 +266,13 @@ func findNearestNodeModuleDir(dir string) (string, error) {
 			return nodeModuleDir, nil
 		}
 
-		dir = filepath.Dir(dir)
-		if isRootDir(dir) {
+		upperDir := filepath.Dir(dir)
+		
+		if isRootDir(upperDir) || upperDir == dir {
 			return "", nil
 		}
+		
+		dir = upperDir
 	}
 }
 


### PR DESCRIPTION
`findNearestNodeModuleDir` hangs in an infinite loop it fails to detect that it is looking at the parent of a root dir.

Therefore, this patch exists the loop when the parent of the current dir is the same as the dir itself (i.e. root dir)

This should fix https://github.com/develar/app-builder/issues/2