### PR TITLE
Fix panic when remote build URL returns error

### DIFF
--- a/pkg/remoteBuild/buildAgentEndpoint.go
+++ b/pkg/remoteBuild/buildAgentEndpoint.go
@@ -50,6 +50,10 @@ func findBuildAgent(transport *http.Transport) (string, error) {
 func getBuildAgentEndpoint(client *http.Client, url string) (string, error) {
 	response, err := client.Get(url)
 
+	if err != nil {
+		return "", err
+	}
+
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -58,10 +62,6 @@ func getBuildAgentEndpoint(client *http.Client, url string) (string, error) {
 		if response.StatusCode != http.StatusOK {
 			err = fmt.Errorf("cannot get %s: http error %d", url, response.StatusCode)
 		}
-	}
-
-	if err != nil {
-		return "", err
 	}
 
 	bodyBytes, err := ioutil.ReadAll(response.Body)


### PR DESCRIPTION
Okay, when remote URL returns an error (SSL invalid certificate in my case), the app crashes with panic. This should fix it.
Building still doesn't work for me, as the SSL issue persists, but at least crashing should be fixed.