### PR TITLE
fix: APPDIR (in AppRun.sh template) may contain spaces

### DIFF
--- a/pkg/package-format/appimage/templates/AppRun.sh
+++ b/pkg/package-format/appimage/templates/AppRun.sh
@@ -16,7 +16,7 @@ NUMBER_OF_ARGS="$#"
 # such as desktop integration daemons
 VENDORPREFIX=appimagekit
 
-if [ -z $APPDIR ] ; then
+if [ -z "$APPDIR" ] ; then
   # Find the AppDir. It is the directory that contains AppRun.
   # This assumes that this script resides inside the AppDir or a subdirectory.
   # If this script is run inside an AppImage, then the AppImage runtime likely has already set $APPDIR

--- a/pkg/package-format/bindata.go
+++ b/pkg/package-format/bindata.go
@@ -81,7 +81,7 @@ func appimageTemplatesApprunSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "appimage/templates/AppRun.sh", size: 8022, mode: os.FileMode(493), modTime: time.Unix(1543214019, 0)}
+	info := bindataFileInfo{name: "appimage/templates/AppRun.sh", size: 8024, mode: os.FileMode(493), modTime: time.Unix(1554315247, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Wherever mktemp is invoked, it seems to take 6 characters from project name, prefix it with `.mount_` and suffix with a few random characters. If there is a space in those first 6 characters (for example the project may be called “Abc Blahblah”), the `[ -z $APPDIR ]` test fails with something like “unexpected operator” (the test may look like `[ -z Abc Blahblah ]`).