### PR TITLE
fix(download-artifacts): download winCodeSign, zstd, fpm from other hosts than github

### DIFF
--- a/pkg/download/artifactDownloader.go
+++ b/pkg/download/artifactDownloader.go
@@ -60,13 +60,17 @@ func GetCacheDirectoryForArtifactCustom(dirName string) (string, error) {
 // * don't pollute user project dir (important in case of 1-package.json project structure)
 // * simplify/speed-up tests (don't download fpm for each test project)
 func DownloadArtifact(dirName string, url string, checksum string) (string, error) {
-	switch dirName {
-	case "fpm":
-		return DownloadFpm()
-	case "zstd":
-		return DownloadZstd(util.GetCurrentOs())
-	case "winCodeSign":
-		return DownloadWinCodeSign()
+
+	if len(url) == 0 {
+		// if no url is provided download these artifacts from Github. Otherwise use the provided url to download the artifacts.
+		switch dirName {
+		case "fpm":
+			return DownloadFpm()
+		case "zstd":
+			return DownloadZstd(util.GetCurrentOs())
+		case "winCodeSign":
+			return DownloadWinCodeSign()
+		}
 	}
 
 	if len(dirName) == 0 {


### PR DESCRIPTION
This PR is corresponding to electron-userland/electron-builder#3761.

Even if an specific url is passed for winCodeSign/zstd/fpm it is ignored.
So I added a check if an url is passed and then download these artifacts from the given url.