### PR TITLE
Log package.json location if error during read

### DIFF
--- a/pkg/node-modules/tree.go
+++ b/pkg/node-modules/tree.go
@@ -385,6 +385,7 @@ func readPackageJson(dir string) (*Dependency, error) {
 	var dependency Dependency
 	err = jsoniter.Unmarshal(data, &dependency)
 	if err != nil {
+		log.Error("Error reading package.json: " + filepath.Join(dir, "package.json"))
 		return nil, errors.WithStack(err)
 	}
 


### PR DESCRIPTION
There are more robust ways to do this, but here's a nice and simple option. Will really help folks using electron-builder when they run into the dreaded invalid package error.

Related:

#15 
https://github.com/electron-userland/electron-builder/issues/3765
https://github.com/electron-userland/electron-builder/issues/3050

Simply logs out the location of the offending package.json:

<img width="973" alt="Screen Shot 2019-06-11 at 7 30 24 PM" src="https://user-images.githubusercontent.com/847542/59315557-d0016b80-8c7f-11e9-9cb0-f0dff209737c.png">
