### PR TITLE
Support pacman compression arguments

### DIFF
--- a/pkg/package-format/fpm/fpm.go
+++ b/pkg/package-format/fpm/fpm.go
@@ -107,6 +107,8 @@ func configureTargetSpecific(target string, args []string, compression string) [
 		}
 	} else if target == "deb" {
 		args = append(args, "--deb-compression", compression)
+	} else if target == "pacman" {
+		args = append(args, "--pacman-compression", compression)
 	}
 	return args
 }


### PR DESCRIPTION
Even though electron-builder supports setting compression for pacman targets, app-builder doesn't pass it along to fpm. This should fix that.