### PR TITLE
feat: electron builder binaries base url from env

### DIFF
--- a/pkg/download/tool.go
+++ b/pkg/download/tool.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -27,7 +28,7 @@ func DownloadFpm() (string, error) {
 		name := "fpm-1.9.3-2.3.1-linux" + archSuffix
 		return DownloadArtifact(
 			name,
-			"https://github.com/electron-userland/electron-builder-binaries/releases/download/"+name+"/"+name+".7z",
+			GetGithubBaseUrl()+name+"/"+name+".7z",
 			checksum,
 		)
 	} else {
@@ -59,7 +60,24 @@ func DownloadWinCodeSign() (string, error) {
 
 func downloadFromGithub(name string, version string, checksum string) (string, error) {
 	id := name + "-" + version
-	return DownloadArtifact(id, "https://github.com/electron-userland/electron-builder-binaries/releases/download/"+id+"/"+id+".7z", checksum)
+	return DownloadArtifact(id, GetGithubBaseUrl()+id+"/"+id+".7z", checksum)
+}
+
+func GetGithubBaseUrl() string {
+	v := os.Getenv("NPM_CONFIG_ELECTRON_BUILDER_BINARIES_MIRROR")
+	if len(v) == 0 {
+		v = os.Getenv("npm_config_electron_builder_binaries_mirror")
+	}
+	if len(v) == 0 {
+		v = os.Getenv("npm_package_config_electron_builder_binaries_mirror")
+	}
+	if len(v) == 0 {
+		v = os.Getenv("ELECTRON_BUILDER_BINARIES_MIRROR")
+	}
+	if len(v) == 0 {
+		v = "https://github.com/electron-userland/electron-builder-binaries/releases/download/"
+	}
+	return v
 }
 
 func DownloadTool(descriptor ToolDescriptor, osName util.OsName) (string, error) {

--- a/pkg/linuxTools/tool.go
+++ b/pkg/linuxTools/tool.go
@@ -14,7 +14,7 @@ func GetAppImageToolDir() (string, error) {
 	dirName := "appimage-12.0.1"
 	//noinspection SpellCheckingInspection
 	result, err := download.DownloadArtifact("",
-		"https://github.com/electron-userland/electron-builder-binaries/releases/download/"+dirName+"/"+dirName+".7z",
+		download.GetGithubBaseUrl()+dirName+"/"+dirName+".7z",
 		"3el6RUh6XoYJCI/ZOApyb0LLU/gSxDntVZ46R6+JNEANzfSo7/TfrzCRp5KlDo35c24r3ZOP7nnw4RqHwkMRLw==")
 	if err != nil {
 		return "", err

--- a/pkg/package-format/snap/snap.go
+++ b/pkg/package-format/snap/snap.go
@@ -104,9 +104,9 @@ func ResolveTemplateDir(templateFile string, templateUrl string, templateSha512 
 
 	switch templateUrl {
 	case "electron4", "electron4:amd64":
-		return download.DownloadArtifact("", "https://github.com/electron-userland/electron-builder-binaries/releases/download/snap-template-4.0-2/snap-template-electron-4.0-2-amd64.tar.7z", "PYhiQQ5KE4ezraLE7TOT2aFPGkBNjHLRN7C8qAPaC6VckHU3H+0m+JA/Wmx683fKUT2ZBwo9Mp82EuhmQo5WOQ==")
+		return download.DownloadArtifact("", download.GetGithubBaseUrl()+"snap-template-4.0-2/snap-template-electron-4.0-2-amd64.tar.7z", "PYhiQQ5KE4ezraLE7TOT2aFPGkBNjHLRN7C8qAPaC6VckHU3H+0m+JA/Wmx683fKUT2ZBwo9Mp82EuhmQo5WOQ==")
 	case "electron4:armhf", "electron4:arm":
-		return download.DownloadArtifact("", "https://github.com/electron-userland/electron-builder-binaries/releases/download/snap-template-4.0-1/snap-template-electron-4.0-1-armhf.tar.7z", "jK+E0d0kyzBEsFmTEUIsumtikH4XZp8NVs6DBtIBJqXAmVCuNHcmvDa0wcaigk8foU4uGZXsLlJtNj11X100Bg==")
+		return download.DownloadArtifact("", download.GetGithubBaseUrl()+"snap-template-4.0-1/snap-template-electron-4.0-1-armhf.tar.7z", "jK+E0d0kyzBEsFmTEUIsumtikH4XZp8NVs6DBtIBJqXAmVCuNHcmvDa0wcaigk8foU4uGZXsLlJtNj11X100Bg==")
 	default:
 		return download.DownloadArtifact("", templateUrl, templateSha512)
 	}

--- a/pkg/wine/wine.go
+++ b/pkg/wine/wine.go
@@ -122,7 +122,7 @@ func executeMacOsWine(useSystemWine bool, ctx context.Context, args []string, ia
 		dirName := "wine-4.0.1-mac"
 		//noinspection SpellCheckingInspection
 		checksum := "aCUQOyuPGlEvLMp0lPzb54D96+8IcLwmKTMElrZZqVWtEL1LQC7L9XpPv4RqaLX3BOeSifneEi4j9DpYdC1DCA=="
-		wineDir, err = download.DownloadArtifact(dirName, "https://github.com/electron-userland/electron-builder-binaries/releases/download/"+dirName+"/"+dirName+".7z", checksum)
+		wineDir, err = download.DownloadArtifact(dirName, download.GetGithubBaseUrl()+dirName+"/"+dirName+".7z", checksum)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ func executeMacOsWine(useSystemWine bool, ctx context.Context, args []string, ia
 		dirName := "wine-2.0.3-mac-10.13"
 		//noinspection SpellCheckingInspection
 		checksum := "dlEVCf0YKP5IEiOKPNE48Q8NKXbXVdhuaI9hG2oyDEay2c+93PE5qls7XUbIYq4Xi1gRK8fkWeCtzN2oLpVQtg=="
-		wineDir, err = download.DownloadArtifact(dirName, "https://github.com/electron-userland/electron-builder-binaries/releases/download/"+dirName+"/"+dirName+".7z", checksum)
+		wineDir, err = download.DownloadArtifact(dirName, download.GetGithubBaseUrl()+dirName+"/"+dirName+".7z", checksum)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Added function to get the base URL for GitHub (electron-builder-binaries) using environment variables used by electron-builder (https://github.com/electron-userland/electron-builder/blob/f3404d32f029dfb63e83067012f15ef67838f326/packages/app-builder-lib/src/binDownload.ts#L21-L25).
This could also be extended in a similar way for "ELECTRON_BUILDER_BINARIES_CUSTOM_DIR".
The implantation is not tested, however it is structured the same way as https://github.com/develar/app-builder/blob/7e03397c8b546e001217ab3cac41900fab189bf9/pkg/electron/electronDownloader.go#L84-L99 and should work without any problems.