### PR TITLE
Add WSL (Windows Subsystem for Linux) support

### DIFF
--- a/pkg/rcedit/rcedit.go
+++ b/pkg/rcedit/rcedit.go
@@ -42,8 +42,11 @@ func editResources(args []string) error {
 
 		rcEditPath := filepath.Join(winCodeSignPath, rcEditExecutable)
 
-		if (util.IsWSL()) {
-			os.Chmod(rcEditPath, 0755)
+		if util.IsWSL() {
+			err = os.Chmod(rcEditPath, 0755)
+			if err != nil {
+				return err
+			}
 		}
 
 		command := exec.Command(rcEditPath, args...)

--- a/pkg/rcedit/rcedit.go
+++ b/pkg/rcedit/rcedit.go
@@ -1,6 +1,7 @@
 package rcedit
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -31,7 +32,7 @@ func editResources(args []string) error {
 		return err
 	}
 
-	if util.GetCurrentOs() == util.WINDOWS {
+	if util.GetCurrentOs() == util.WINDOWS || util.IsWSL() {
 		var rcEditExecutable string
 		if runtime.GOARCH == "amd64" {
 			rcEditExecutable = "rcedit-x64.exe"
@@ -39,7 +40,13 @@ func editResources(args []string) error {
 			rcEditExecutable = "rcedit-ia32.exe"
 		}
 
-		command := exec.Command(filepath.Join(winCodeSignPath, rcEditExecutable), args...)
+		rcEditPath := filepath.Join(winCodeSignPath, rcEditExecutable)
+
+		if (util.IsWSL()) {
+			os.Chmod(rcEditPath, 0755)
+		}
+
+		command := exec.Command(rcEditPath, args...)
 		_, err = util.Execute(command)
 		if err != nil {
 			return err

--- a/pkg/util/wsl.go
+++ b/pkg/util/wsl.go
@@ -12,7 +12,7 @@ func IsWSL() bool {
 		return false
 	}
 
-	err, release := getOSRelease()
+	release, err := getOSRelease()
 	if err != nil {
 		return false
 	}
@@ -21,7 +21,7 @@ func IsWSL() bool {
 		return true
 	}
 
-	err, version := getProcVersion()
+	version, err := getProcVersion()
 	if err != nil {
 		return false
 	}
@@ -33,7 +33,7 @@ func IsWSL() bool {
 	return false
 }
 
-func getOSRelease() (error, string) {
+func getOSRelease() (string, error) {
 	cmd := exec.Command("uname","-r")
 
 	var out bytes.Buffer
@@ -43,17 +43,17 @@ func getOSRelease() (error, string) {
 	
 	err := cmd.Run()
 	if err != nil {
-		return err, ""
+		return "", err
 	}
 
-	return nil, out.String()
+	return out.String(), nil
 }
 
-func getProcVersion() (error, string) {
+func getProcVersion() (string, error) {
 	content, err := ioutil.ReadFile("/proc/version")
 	if err != nil {
-		return err, ""
+		return "", err
 	}
 
-	return nil, string(content)
+	return string(content), nil
 }

--- a/pkg/util/wsl.go
+++ b/pkg/util/wsl.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+)
+
+func IsWSL() bool {
+	if GetCurrentOs() != LINUX {
+		return false
+	}
+
+	err, release := getOSRelease()
+	if err != nil {
+		return false
+	}
+
+	if strings.Contains(strings.ToLower(release), "microsoft") {
+		return true
+	}
+
+	err, version := getProcVersion()
+	if err != nil {
+		return false
+	}
+
+	if strings.Contains(strings.ToLower(version), "microsoft") {
+		return true
+	}
+
+	return false
+}
+
+func getOSRelease() (error, string) {
+	cmd := exec.Command("uname","-r")
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	
+	err := cmd.Run()
+	if err != nil {
+		return err, ""
+	}
+
+	return nil, out.String()
+}
+
+func getProcVersion() (error, string) {
+	content, err := ioutil.ReadFile("/proc/version")
+	if err != nil {
+		return err, ""
+	}
+
+	return nil, string(content)
+}


### PR DESCRIPTION
Hello,

Thank you for making this package!

I tried to use it on `WSL` (Windows Subsystem for Linux).
`WSL` is a Linux specially built for running seemlessly.

It could not use `wine` due to kernel differences but it can call Win32 executables (`.exe`) directly.

I make an improvement to your lib to detect `WSL` and call `rcedit.exe` directly rather than using `wine`.

*Note: I'm also working on a `electron-builder` PR to add `WSL` support. This PR will require this change on `app-builder`*

Thanks