### PR TITLE
fix(linux): remove libappindicator-sharp from pacman dependency list

### DIFF
--- a/pkg/package-format/fpm/fpm.go
+++ b/pkg/package-format/fpm/fpm.go
@@ -143,7 +143,7 @@ func getDefaultDepends(target string) []string {
 		}
 
 	case "pacman":
-		return []string{"c-ares", "ffmpeg", "gtk3", "http-parser", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy", "libnotify", "libappindicator-gtk3", "libappindicator-sharp"}
+		return []string{"c-ares", "ffmpeg", "gtk3", "http-parser", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy", "libnotify", "libappindicator-gtk3"}
 
 	default:
 		return nil


### PR DESCRIPTION
Arch Linux no longer distributes the "obsoleted" libappindicator-sharp
package.
https://lists.archlinux.org/pipermail/arch-commits/2020-March/722392.html