### PR TITLE
Binary plist to XMLFormat

### DIFF
--- a/pkg/plist/plist.go
+++ b/pkg/plist/plist.go
@@ -44,7 +44,7 @@ func encode() error {
 		data := fileToData[file]
 		return func() error {
 			var out bytes.Buffer
-			err := plist.NewEncoderForFormat(&out, plist.BinaryFormat).Encode(data)
+			err := plist.NewEncoderForFormat(&out, plist.XMLFormat).Encode(data)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
In binary you can't sign and notarizing for publish in App Store