### PR TITLE
fix(snap): remove incorrect usage of --target-arch for snapcraft

### DIFF
--- a/pkg/package-format/snap/snap.go
+++ b/pkg/package-format/snap/snap.go
@@ -1,6 +1,7 @@
 package snap
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -329,7 +330,9 @@ func buildWithoutTemplate(options SnapOptions, scriptDir string) error {
 	var args []string
 	args = append(args, "snap", "--output", snapEffectiveOutput)
 	if len(*options.arch) != 0 {
-		args = append(args, "--target-arch", *options.arch)
+		if *options.arch != runtime.GOARCH {
+			return fmt.Errorf("snapcraft does not currently support building %s on %s", *options.arch, runtime.GOARCH)
+		}
 	}
 
 	if isDestructiveMode {


### PR DESCRIPTION
Snapcraft has ignored the target-arch flag, which works in very
limited circumstances, with destructive mode.  Snapcraft considers
it unsupported and will not be fixed in its current form.

Recently snapcraft regarded improper usage of this as a hard error
instead of silently ignoring, which broke users of app-builder. We
reverted that to simply warn, but this fix is to remove its usage
from app-builder.

If the user is targeting an arch that is not the host arch,
error out with a nice message.

However, it does require that --arch with `snap` must use the
scheme provided by go. If there are a set of supported architecture
options somewhere, I can update to ensure that they map to GOARCH.

Closes: #40

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>