### PR TITLE
fix: instruct prebuild-install to download napi builds

### DIFF
--- a/pkg/node-modules/nodeModuleCollector.go
+++ b/pkg/node-modules/nodeModuleCollector.go
@@ -12,11 +12,16 @@ import (
 	"go.uber.org/zap"
 )
 
+type DependencyBinary struct {
+	NapiVersions []uint `json:"napi_versions"`
+}
+
 type Dependency struct {
 	Name                 string            `json:"name"`
 	Version              string            `json:"version"`
 	Dependencies         map[string]string `json:"dependencies"`
 	OptionalDependencies map[string]string `json:"optionalDependencies"`
+	Binary*              DependencyBinary  `json:"binary`
 
 	dir string
 	isOptional int

--- a/pkg/node-modules/tree.go
+++ b/pkg/node-modules/tree.go
@@ -140,6 +140,18 @@ func writeDependencyList(jsonWriter *jsoniter.Stream, dependencyMap *map[string]
 			}
 		}
 
+		if info.Binary != nil {
+			jsonWriter.WriteMore()
+			jsonWriter.WriteObjectField("napiVersions")
+			jsonWriter.WriteArrayStart()
+
+			for _, v := range info.Binary.NapiVersions {
+				jsonWriter.WriteUint(v)
+			}
+
+			jsonWriter.WriteArrayEnd()
+		}
+
 		jsonWriter.WriteObjectEnd()
 	}
 	jsonWriter.WriteArrayEnd()


### PR DESCRIPTION
fixes #46 

Before:
```
julus@julus-thinkpad:~/Projects/companion-build/test$ yarn electron-builder install-app-deps --platform win32
yarn run v1.22.5
$ /home/julus/Projects/companion-build/test/node_modules/.bin/electron-builder install-app-deps --platform win32
  • electron-builder  version=22.9.1
  • rebuilding native dependencies  dependencies=node-hid@2.1.1 platform=win32 arch=x64
  • install prebuilt binary  name=node-hid version=2.1.1 platform=win32 arch=x64
  ⨯ cannot build native dependency  reason=prebuild-install failed with error and build from sources not possible because platform or arch not compatible
                                    cause=exit status 1
                                    errorOut=prebuild-install info begin Prebuild-install version 6.0.0
    prebuild-install info looking for cached prebuild @ /home/julus/.npm/_prebuilds/1d45c9-node-hid-v2.1.1-electron-v80-win32-x64.tar.gz
    prebuild-install http request GET https://github.com/node-hid/node-hid/releases/download/v2.1.1/node-hid-v2.1.1-electron-v80-win32-x64.tar.gz
    prebuild-install http 404 https://github.com/node-hid/node-hid/releases/download/v2.1.1/node-hid-v2.1.1-electron-v80-win32-x64.tar.gz
    prebuild-install WARN install No prebuilt binaries found (target=9.4.0 runtime=electron arch=x64 libc= platform=win32)
    
                                    command=/usr/bin/node /home/julus/Projects/companion-build/test/node_modules/prebuild-install/bin.js --platform=win32 --arch=x64 --target=9.4.0 --runtime=electron --verbose --force
                                    workingDir=/home/julus/Projects/companion-build/test/node_modules/node-hid
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After:
```
julus@julus-thinkpad:~/Projects/companion-build/test$ yarn electron-builder install-app-deps --platform win32
yarn run v1.22.5
$ /home/julus/Projects/companion-build/test/node_modules/.bin/electron-builder install-app-deps --platform win32
  • electron-builder  version=22.9.1
  • rebuilding native dependencies  dependencies=node-hid@2.1.1 platform=win32 arch=x64
  • install prebuilt binary  name=node-hid version=2.1.1 platform=win32 arch=x64 napi= 
Done in 1.04s.
```

I don't know why the `napi= ` bit in the log line is blank, I believe I am using the correct zap method to convert it, but it ends up blank even when there are values. Do you have any ideas on what I did wrong?