### PR TITLE
fix: Snaps fail when user has symlinked XDG_SPECIAL_DIRS in HOME

### DIFF
--- a/pkg/package-format/snap/desktop-scripts/desktop-common.sh
+++ b/pkg/package-format/snap/desktop-scripts/desktop-common.sh
@@ -219,7 +219,8 @@ else
   for ((i = 0; i < ${#XDG_SPECIAL_DIRS[@]}; i++)); do
     old="${XDG_SPECIAL_DIRS_INITIAL_PATHS[$i]}"
     new="${XDG_SPECIAL_DIRS_PATHS[$i]}"
-    if [ -L "$old" ] && [ -d "$new" ] && [ "$(readlink "$old")" != "$new" ]; then
+    if [ -L "$old" ] && [ -d "$new" ] && [ "$(readlink "$old")" != "$new" ] &&
+         (is_subpath "$old" "$SNAP_USER_DATA" || is_subpath "$old" "$SNAP_USER_COMMON"); then
       mv -vn "$old"/* "$new"/ 2>/dev/null
     elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ] &&
          (is_subpath "$old" "$SNAP_USER_DATA" || is_subpath "$old" "$SNAP_USER_COMMON"); then


### PR DESCRIPTION
When a user has one or several `XDG_SPECIAL_DIRS` folders symlinked in
their real home folder to elsewhere in their real home folder
`desktop-common.sh` will attempt to mv those folders to themselves.
Because we are executing this script with `bash -e`, this prevents any
Snap with the `home` interface built with these scripts from launching
when the user has moved any of their Documents, Pictures, Music, etc.
and replaced with a symlink.

* guard `mv` calls with test for `is_subpath` to ensure that we're only
  moving symlinks we created.

See related PRs on Snapcraft-desktop-helpers and Snapcraft:

* ubuntu/snapcraft-desktop-helpers#220
* snapcore/snapcraft#3435

Signed-off-by: Daniel Llewellyn <diddledan@ubuntu.com>