### PR TITLE
Use 32-bit (ia32) app-builder.exe on Windows ARM64

### DIFF
--- a/app-builder-bin/index.js
+++ b/app-builder-bin/index.js
@@ -11,6 +11,15 @@ function getPath() {
   if (platform === "darwin") {
     return path.join(__dirname, "mac", "app-builder")
   }
+  else if (platform === "win32" && process.arch == "arm64") {
+    /**
+     * Golang isn't available for Windows ARM64 yet, so an ARM64 binary
+     * can't be built yet. However, Windows ARM64 does support ia32
+     * emulation, so we can leverage the existing executable for ia32.
+     * https://github.com/golang/go/issues/36439
+     */
+    return path.join(__dirname, "win", "ia32", "app-builder.exe")
+  }
   else if (platform === "win32") {
     return path.join(__dirname, "win", process.arch, "app-builder.exe")
   }


### PR DESCRIPTION
Currently, running `electron-builder` on Windows ARM64 leads to the following error:

```
• electron-builder  version=22.9.1
  • loaded configuration  file=package.json ("build" field)
  ⨯ spawn C:\repos\Signal-Desktop\node_modules\app-builder-bin\win\arm64\app-builder.exe ENOENT  stackTrace=
                   Error: spawn C:\repos\Signal-Desktop\node_modules\app-builder-bin\win\arm64\app-builder.exe ENOENT
                       at Process.ChildProcess._handle.onexit (internal/child_process.js:269:19)
                       at onErrorNT (internal/child_process.js:465:16)
                       at processTicksAndRejections (internal/process/task_queues.js:80:21)
```

This is because there's no binary for Windows ARM64 yet. This PR works around that.

**Some background**
Golang isn't available for Windows ARM64 yet, so an ARM64 binary can't be built yet. However, Windows ARM64 does support ia32 emulation, so we can leverage the existing executable for ia32. Ref: https://github.com/golang/go/issues/36439