### PR TITLE
Add support for darwin arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ dist/
 vendor/
 
 app-builder-bin/readme.md
-app-builder-bin/**/app-builder
+app-builder-bin/**/app-builder*
 app-builder-bin/win/**/app-builder.exe
 
 /.idea/shelf/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ else
 		OS_ARCH := linux_amd64
 	endif
 	ifeq ($(UNAME_S),Darwin)
-		OS_ARCH := darwin_amd64
+		OS_ARCH := darwin_$(shell uname -m)
 	endif
 endif
 

--- a/app-builder-bin/index.js
+++ b/app-builder-bin/index.js
@@ -9,7 +9,7 @@ function getPath() {
 
   const platform = process.platform;
   if (platform === "darwin") {
-    return path.join(__dirname, "mac", "app-builder")
+    return path.join(__dirname, "mac", `app-builder_${process.arch}`)
   }
   else if (platform === "win32" && process.arch == "arm64") {
     /**

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,9 @@ rm -rf mac
 rm -rf linux
 
 mkdir mac
-GOOS=darwin GOARCH=amd64 go build -ldflags='-s -w' -o mac/app-builder ..
+GOOS=darwin GOARCH=amd64 go build -ldflags='-s -w' -o mac/app-builder_amd64 ..
+GOOS=darwin GOARCH=arm64 go build -ldflags='-s -w' -o mac/app-builder_arm64 ..
+ln -s app-builder_amd64 mac/app-builder
 
 mkdir -p linux/ia32
 GOOS=linux GOARCH=386 go build -ldflags='-s -w' -o linux/ia32/app-builder ..


### PR DESCRIPTION
Configures the build so that it can produce executables for darwin arm64, AKA "M1" Macs.

Because Go can't yet build universal binaries alone, and the Apple supplied tool to build universal binaries is unavailable on non-Darwin platforms, we simply build and distribute versions of the executable for both architectures, and select the appropriate one at runtime in Javascript. For backwards compatibility, an `app-builder` symlink to the amd64 executable is maintained.

Resolves issue #56.