### PR TITLE
Check whole hashbang line if it is /usr/bin/env

### DIFF
--- a/pkg/node-modules/rebuild.go
+++ b/pkg/node-modules/rebuild.go
@@ -442,6 +442,8 @@ func readHashBang(path string) (string, error) {
 		end := strings.IndexAny(str, "\r\n\t ")
 		if end == -1 {
 			end = len(str)
+		} else if str[0:end] == "/usr/bin/env" {
+			end = strings.IndexAny(str, "\r\n\t")
 		}
 		return str[0:end], nil
 		} else {


### PR DESCRIPTION
Would fix #63.

Because pnpm uses the hashbang `/usr/bin/env node`, only checking until the first space as is current done will miss the `node`.

This change will only include the space if the text before the space is "/usr/bin/env", so that it doesn't break any existing code (`/usr/bin/env` would fail the check anyway)

This fix is working in my [minimum reproduction of the issue](https://github.com/Alduino/app-builder-navw32a-repro/runs/3534414708) (the Test stage)

Running it in the original repository that I found the bug in, it is getting past where it got before (it doesn't get the %1 is not a valid command error) but now at the end of the postinstall it [gets another error](https://github.com/Alduino/Muzik/runs/3534341190) (Install & Build stage):

```
apps/desktop postinstall: 'li.js" install-app-deps' is not recognized as an internal or external command,
apps/desktop postinstall: operable program or batch file.
apps/desktop postinstall:   • exited          command=app-builder.exe code=0 pid=6960
apps/desktop postinstall: D:\a\Muzik\Muzik\apps\desktop>li.js" install-app-deps
```

I'm not sure if that is caused by this change or not though, because there is no ground truth to compare to.