### PR TITLE
fix: incorrect enums for updated appimage-13 mksquashfs compressors

### DIFF
--- a/pkg/package-format/appimage/appImage.go
+++ b/pkg/package-format/appimage/appImage.go
@@ -43,7 +43,7 @@ func ConfigureCommand(app *kingpin.Application) {
 		template: command.Flag("template", "The template file.").String(),
 		license:  command.Flag("license", "The license file.").String(),
 
-		compression: command.Flag("compression", "The compression.").Enum("xz", "gzip"),
+		compression: command.Flag("compression", "The compression.").Default("zstd").Enum("xz", "lzo", "zstd"),
 	}
 
 	configuration := command.Flag("configuration", "").Required().String()


### PR DESCRIPTION
See: https://github.com/electron-userland/electron-builder/issues/6678
```
• electron-builder  version=23.0.1 os=5.15.25-1-lts
• loaded configuration  file=/home/mscharley/Code/mscharley/notes-nc/electron-builder.yml
• writing effective config  file=dist/builder-effective-config.yaml
• packaging       platform=linux arch=x64 electron=17.1.0 appOutDir=dist/linux-unpacked
• building        target=AppImage arch=x64 file=dist/notes-nc-0.3.0.AppImage
• default Electron icon is used  reason=application icon is not set
⨯ enum value must be one of xz,gzip, got 'zlib'
```
```
  ⨯ enum value must be one of xz,gzip, got 'lzo'
  ⨯ /home/mscharley/Code/mscharley/notes-nc/node_modules/app-builder-bin/linux/x64/app-builder process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
```
```
$ electron-builder --publish never

  • electron-builder  version=23.0.0-alpha.2 os=5.15.19-1-lts
  • loaded configuration  file=/home/mscharley/Code/mscharley/app/electron-builder.yml
  • writing effective config  file=dist/builder-effective-config.yaml
  • packaging       platform=linux arch=x64 electron=17.0.0 appOutDir=dist/linux-unpacked
  • building        target=AppImage arch=x64 file=dist/app-0.1.0.AppImage
  • default Electron icon is used  reason=application icon is not set

$ ./dist/app-0.1.0.AppImage
Squashfs image uses (null) compression, this version supports only xz, zlib.
```
```
• electron-builder  version=23.0.1 os=4.18.0-15-generic
• loaded configuration  file=package.json ("build" field)
• writing effective config  file=build/builder-effective-config.yaml
• rebuilding native dependencies  dependencies=bufferutil@4.0.6, utf-8-validate@5.0.8 platform=linux arch=x64
• packaging       platform=linux arch=x64 electron=13.6.9 appOutDir=build/linux-unpacked
• building        target=AppImage arch=x64 file=build/lx-music-desktop v1.18.0 x64.AppImage
⨯ cannot execute  cause=exit status 1
                errorOut=/home/user/.cache/electron-builder/appimage/appimage-13.0.0/linux-x64/mksquashfs: Compressor "gzip" is not supported!
/home/user/.cache/electron-builder/appimage/appimage-13.0.0/linux-x64/mksquashfs: Compressors available:
  lzo
  xz
  zstd (default)
```

I don't know how to test this, I'm just going off the error logs. The upgrade to AppImage-13 with updated mksquashfs has broken the command `appimage` for 4.0.1