### PR TITLE
Add Windows ARM64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ OS_ARCH = ""
 ifeq ($(OS),Windows_NT)
 	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
 		OS_ARCH := windows_amd64
+	else ifeq ($(PROCESSOR_ARCHITEW6432),ARM64)
+		OS_ARCH := windows_arm64
 	else
 		OS_ARCH := windows_386
 	endif

--- a/app-builder-bin/index.js
+++ b/app-builder-bin/index.js
@@ -12,15 +12,6 @@ function getPath() {
   if (platform === "darwin") {
     return path.join(__dirname, "mac", `app-builder_${arch === "x64" ? "amd64" : arch}`)
   }
-  else if (platform === "win32" && arch === "arm64") {
-    /**
-     * Golang isn't available for Windows ARM64 yet, so an ARM64 binary
-     * can't be built yet. However, Windows ARM64 does support ia32
-     * emulation, so we can leverage the existing executable for ia32.
-     * https://github.com/golang/go/issues/36439
-     */
-    return path.join(__dirname, "win", "ia32", "app-builder.exe")
-  }
   else if (platform === "win32") {
     return path.join(__dirname, "win", arch, "app-builder.exe")
   }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,3 +31,7 @@ GOOS=windows GOARCH=386 go build -o win/ia32/app-builder.exe ..
 mkdir -p win/x64
 # set GOARCH=amd64
 GOOS=windows GOARCH=amd64 go build -o win/x64/app-builder.exe ..
+
+mkdir -p win/arm64
+# set GOARCH=arm64
+GOOS=windows GOARCH=arm64 go build -o win/arm64/app-builder.exe ..


### PR DESCRIPTION
Go supports Windows ARM64 since Go 1.17, so it's not possible to create native builds for `app-builder-bin`.