### PR TITLE
Use snapcraft upload instead of push

### DIFF
--- a/pkg/package-format/snap/snap.go
+++ b/pkg/package-format/snap/snap.go
@@ -149,8 +149,8 @@ func doCheckSnapVersion(rawVersion string, installMessage string) error {
 	s = strings.TrimSpace(strings.TrimPrefix(s, ","))
 	s = strings.TrimSpace(strings.TrimPrefix(s, "version"))
 	s = strings.Trim(s, "'")
-	if version.Compare(s, "3.1.0", "<") {
-		return util.NewMessageError("at least snapcraft 3.1.0 is required, but "+rawVersion+" installed, please: "+installMessage, "ERR_SNAPCRAFT_OUTDATED")
+	if version.Compare(s, "4.0.0", "<") {
+		return util.NewMessageError("at least snapcraft 4.0.0 is required, but "+rawVersion+" installed, please: "+installMessage, "ERR_SNAPCRAFT_OUTDATED")
 	} else {
 		return nil
 	}

--- a/pkg/package-format/snap/snapStore.go
+++ b/pkg/package-format/snap/snapStore.go
@@ -20,7 +20,7 @@ func ConfigurePublishCommand(app *kingpin.Application) {
 }
 
 func publishToStore(file string, channels []string) error {
-	args := []string{"push", file}
+	args := []string{"upload", file}
 	if len(channels) != 0 {
 		args = append(args, "--release")
 		args = append(args, strings.Join(channels, ","))

--- a/pkg/package-format/snap/snap_test.go
+++ b/pkg/package-format/snap/snap_test.go
@@ -9,18 +9,18 @@ import (
 func TestCheckWineVersion(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	err := doCheckSnapVersion("3.1", "")
+	err := doCheckSnapVersion("4.0", "")
 	g.Expect(err).NotTo(HaveOccurred())
 
-	err = doCheckSnapVersion("snapcraft, version 3.1.1", "")
+	err = doCheckSnapVersion("snapcraft, version 4.0.0", "")
 	g.Expect(err).NotTo(HaveOccurred())
 
-	err = doCheckSnapVersion("snapcraft, version '3.1.1'", "")
+	err = doCheckSnapVersion("snapcraft, version '4.0.0'", "")
 	g.Expect(err).NotTo(HaveOccurred())
 
-	err = doCheckSnapVersion(" version 3.2.1", "")
+	err = doCheckSnapVersion(" version 4.1.1", "")
 	g.Expect(err).NotTo(HaveOccurred())
 
-	err = doCheckSnapVersion("2.12", "")
+	err = doCheckSnapVersion("3.1", "")
 	g.Expect(err).To(HaveOccurred())
 }


### PR DESCRIPTION
Addresses the [deprecation warning](http://snapcraft.io/docs/deprecation-notices/dn11):
```
DEPRECATED: The 'push' set of commands have been replaced with 'upload'.
See http://snapcraft.io/docs/deprecation-notices/dn11 for more information.
```

Requires the use of Snapcraft 4.0.