### PR TITLE
feat: add ppc64le support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,14 @@ ifeq ($(OS),Windows_NT)
 	endif
 else
 	UNAME_S := $(shell uname -s)
+	UNAME_M := $(shell uname -m)
 	ifeq ($(UNAME_S),Linux)
-		OS_ARCH := linux_amd64
+		# uname -m returns ppc64le on little endian systems, so we check if it contains ppc64 instead of an exact match
+		ifneq (,$(findstring ppc64,$(UNAME_M)))
+			OS_ARCH := linux_ppc64
+		else
+			OS_ARCH := linux_amd64
+		endif
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		OS_ARCH := darwin_$(shell uname -m)


### PR DESCRIPTION
I've packaged this for Gentoo Linux and I'm using it on ppc64le. Works well and I'd like add explicit support in the Makefile so the binary won't end up into the amd64 folder.