### PR TITLE
fix(node-modules): incorrect generation of napi_versions

### DIFF
--- a/pkg/node-modules/tree.go
+++ b/pkg/node-modules/tree.go
@@ -145,7 +145,11 @@ func writeDependencyList(jsonWriter *jsoniter.Stream, dependencyMap *map[string]
 			jsonWriter.WriteObjectField("napiVersions")
 			jsonWriter.WriteArrayStart()
 
-			for _, v := range info.Binary.NapiVersions {
+			for i, v := range info.Binary.NapiVersions {
+				if i != 0 {
+					jsonWriter.WriteMore()
+				}
+
 				jsonWriter.WriteUint(v)
 			}
 


### PR DESCRIPTION
Before:
```
{"name":"zstd-napi","version":"0.0.6","hasPrebuildInstall":true,"napiVersions":[35]}
```

After:

```
{"name":"zstd-napi","version":"0.0.6","hasPrebuildInstall":true,"napiVersions":[3,5]}
```
