### PR TITLE
fix: Incorrect 'node_modules' path for the dependencies.

### DIFF
--- a/pkg/node-modules/nodeModuleCollector.go
+++ b/pkg/node-modules/nodeModuleCollector.go
@@ -55,6 +55,8 @@ func (t *Collector) readDependencyTree(dependency *Dependency) error {
 		return nil
 	}
 
+	nodeModuleDir = fixNodeModuleDir(nodeModuleDir, dependency.Dependencies)
+
 	// process direct children first
 	queue := make([]*Dependency, maxQueueSize)
 	queueIndex := 0
@@ -253,6 +255,55 @@ func findNearestNodeModuleDir(dir string) (string, error) {
 			return "", errors.New("infinite loop: " + dir)
 		}
 	}
+}
+
+func fixNodeModuleDir(nodeModuleDir string, dependencies map[string]string) string {
+	if len(nodeModuleDir) == 0 {
+		return ""
+	}
+
+	result := nodeModuleDir
+	pathList := strings.Split(nodeModuleDir, string(os.PathSeparator))
+
+	check := false
+	missedDeps := make([]string, 0)
+	for i := 0; i < len(pathList); i++ {
+		if check {
+			break
+		}
+
+		path := nodeModuleDir
+		for j := 0; j < i; j++ {
+			path = filepath.Join(path, "..")
+		}
+
+		// check if all dependencies are present
+		for k := range dependencies {
+			fileInfo, err := os.Stat(filepath.Join(path, k))
+			if err != nil || !fileInfo.IsDir() {
+				if !slices.Contains(missedDeps, k) {
+					missedDeps = append(missedDeps, k)
+				}
+				check = false
+			} else {
+				// remove from failed deps if dependency is present
+				for i, v := range missedDeps {
+					if v == k {
+						missedDeps = append(missedDeps[:i], missedDeps[i+1:]...)
+						break
+					}
+				}
+				check = true
+				result = path
+			}
+		}
+	}
+
+	if (len(result) != len(nodeModuleDir)) && len(missedDeps) != 0 && log.IsDebugEnabled() {
+		log.Debug("fixed node_module dir", zap.String("old", nodeModuleDir), zap.String("new", result), zap.Strings("missedDeps", missedDeps))
+	}
+
+	return result
 }
 
 func getParentDir(file string) string {


### PR DESCRIPTION
It fixed the path if the packages contain CLI binaries, causing pnpm/yarn to have a different folder structure than normal packages.

I'm not familiar with Go, but it seems to work.

However, there is another issue that arises in 'app-builder-lib': the root 'node_modules' should create the same symlink folder structure instead of copying the dependencies.

While it doesn't solve #92, it can serve as a starting point.