### PR TITLE
feat: add `CUSTOM_APP_BUILDER_PATH` for testing purposes instead of searching `PATH`

### DIFF
--- a/.changeset/gorgeous-rabbits-sell.md
+++ b/.changeset/gorgeous-rabbits-sell.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": minor
+---
+
+feat: allow providing env var for custom app-builder binary as opposed to accessing directly from the PATH env var

--- a/index.js
+++ b/index.js
@@ -7,8 +7,11 @@ function getPath() {
     return "app-builder"
   }
 
-  const platform = process.platform;
-  const arch = process.arch
+  if (!!process.env.CUSTOM_APP_BUILDER_PATH) {
+    return path.resolve(process.env.CUSTOM_APP_BUILDER_PATH)
+  }
+
+  const { platform, arch } = process;
   if (platform === "darwin") {
     return path.join(__dirname, "mac", `app-builder_${arch === "x64" ? "amd64" : arch}`)
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,20 @@
   },
   "publishConfig": {
     "tag": "next",
-    "git-checks": false
+    "git-checks": false,
+    "executableFiles": [
+      "linux/arm/app-builder",
+      "linux/arm64/app-builder",
+      "linux/ia32/app-builder",
+      "linux/loong64/app-builder",
+      "linux/riscv64/app-builder",
+      "linux/x64/app-builder",
+      "mac/app-builder",
+      "mac/app-builder_amd64",
+      "mac/app-builder_arm64",
+      "win/arm64/app-builder.exe",
+      "win/ia32/app-builder.exe",
+      "win/x64/app-builder.exe"
+    ]
   }
 }


### PR DESCRIPTION
Allow providing env var for custom app-builder binary as opposed to accessing directly from the PATH env var