### PR TITLE
fix: revert appimage 13.0.1 to 13.0.0 due to miscompiled arch artifacts

### DIFF
--- a/.changeset/real-clocks-cheer.md
+++ b/.changeset/real-clocks-cheer.md
@@ -2,4 +2,4 @@
 "app-builder-bin": patch
 ---
 
-fix: revert appimage 13 due to mksquash arch compilation issues
+fix: revert appimage 13.0.1 to 13.0.0 due to mksquash arch compilation issues

--- a/.changeset/real-clocks-cheer.md
+++ b/.changeset/real-clocks-cheer.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": patch
+---
+
+fix: revert appimage 13 due to mksquash arch compilation issues

--- a/pkg/linuxTools/tool.go
+++ b/pkg/linuxTools/tool.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetAppImageToolDir() (string, error) {
-	dirName := "appimage-12.0.0"
+	dirName := "appimage-13.0.0"
 	//noinspection SpellCheckingInspection
 	result, err := download.DownloadArtifact("",
 		download.GetGithubBaseUrl()+dirName+"/"+dirName+".7z",
-		"3el6RUh6XoYJCI/ZOApyb0LLU/gSxDntVZ46R6+JNEANzfSo7/TfrzCRp5KlDo35c24r3ZOP7nnw4RqHwkMRLw==")
+		"hBN7VlhUsFX1Uw4uD1zxkm2Z4VHZqVw45VpBghvokCml07KgG0mzP+AACphrQMlav49hlGX9epAreb4Xxvce9A==")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/linuxTools/tool.go
+++ b/pkg/linuxTools/tool.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetAppImageToolDir() (string, error) {
-	dirName := "appimage-13.0.1"
+	dirName := "appimage-12.0.0"
 	//noinspection SpellCheckingInspection
 	result, err := download.DownloadArtifact("",
 		download.GetGithubBaseUrl()+dirName+"/"+dirName+".7z",
-		"ZG8U7K9Bk71cvP1VDlP+L7hO+HhRTJW6RO0kLgh5hbbJJHhPfoA/kw1hsFeq1pAyez6MxvoDyL/5/O45hX9Jaw==")
+		"3el6RUh6XoYJCI/ZOApyb0LLU/gSxDntVZ46R6+JNEANzfSo7/TfrzCRp5KlDo35c24r3ZOP7nnw4RqHwkMRLw==")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/pull/7774#issuecomment-2002183219