### PR TITLE
fix: use correct compression args as mksquashfs

### DIFF
--- a/.changeset/serious-lizards-invite.md
+++ b/.changeset/serious-lizards-invite.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": patch
+---
+
+fix current mksquashfs version only allows xz and gzip compressions

--- a/pkg/package-format/appimage/appImage.go
+++ b/pkg/package-format/appimage/appImage.go
@@ -43,7 +43,7 @@ func ConfigureCommand(app *kingpin.Application) {
 		template: command.Flag("template", "The template file.").String(),
 		license:  command.Flag("license", "The license file.").String(),
 
-		compression: command.Flag("compression", "The compression.").Default("zstd").Enum("xz", "lzo", "zstd"),
+		compression: command.Flag("compression", "The compression.").Default("gzip").Enum("xz", "gzip"),
 	}
 
 	configuration := command.Flag("configuration", "").Required().String()


### PR DESCRIPTION
Current mksquashfs only allows xz and gzip compression options