### PR TITLE
fix(appimage): remove default and fix compression options

### DIFF
--- a/.changeset/strange-parrots-smoke.md
+++ b/.changeset/strange-parrots-smoke.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": patch
+---
+
+fix: set correct compression enums and remove default

--- a/pkg/package-format/appimage/appImage.go
+++ b/pkg/package-format/appimage/appImage.go
@@ -14,7 +14,7 @@ import (
 	"github.com/develar/app-builder/pkg/linuxTools"
 	"github.com/develar/app-builder/pkg/util"
 	"github.com/develar/errors"
-	"github.com/develar/go-fs-util"
+	fsutil "github.com/develar/go-fs-util"
 )
 
 type AppImageOptions struct {
@@ -43,7 +43,7 @@ func ConfigureCommand(app *kingpin.Application) {
 		template: command.Flag("template", "The template file.").String(),
 		license:  command.Flag("license", "The license file.").String(),
 
-		compression: command.Flag("compression", "The compression.").Default("gzip").Enum("xz", "gzip"),
+		compression: command.Flag("compression", "The compression.").Enum("xz", "lzo", "zstd"),
 	}
 
 	configuration := command.Flag("configuration", "").Required().String()


### PR DESCRIPTION
Resolves: https://github.com/electron-userland/electron-builder/actions/runs/9996522006/job/27631089267?pr=8353

```
 • building        target=AppImage arch=x64 file=/tmp/et-db411cd21f3bbd882f3a5a30c58db6ff/t-EHDsQx/test-project-2/dist/Test App ßW-1.1.0.AppImage
  ⨯ cannot execute  cause=exit status 1
                    errorOut=/root/.cache/electron-builder/appimage/appimage-13.0.0/linux-x64/mksquashfs: Compressor "gzip" is not supported!
    /root/.cache/electron-builder/appimage/appimage-13.0.0/linux-x64/mksquashfs: Compressors available:
    	lzo
    	xz
    	zstd (default)
```