### PR TITLE
fix: downgrade appimage 13.0.0->12.0.1

### DIFF
--- a/.changeset/early-dots-repair.md
+++ b/.changeset/early-dots-repair.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": patch
+---
+
+fix: to resolve appimage issues in electron builder, and since we can't update electron-builder-binaries repo, we should just downgrade to the last working version of appimage

--- a/pkg/linuxTools/tool.go
+++ b/pkg/linuxTools/tool.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/develar/app-builder/pkg/download"
 	"github.com/develar/app-builder/pkg/util"
-	"github.com/develar/go-fs-util"
+	fsutil "github.com/develar/go-fs-util"
 )
 
 func GetAppImageToolDir() (string, error) {
-	dirName := "appimage-13.0.0"
+	dirName := "appimage-12.0.1"
 	//noinspection SpellCheckingInspection
 	result, err := download.DownloadArtifact("",
 		download.GetGithubBaseUrl()+dirName+"/"+dirName+".7z",
-		"hBN7VlhUsFX1Uw4uD1zxkm2Z4VHZqVw45VpBghvokCml07KgG0mzP+AACphrQMlav49hlGX9epAreb4Xxvce9A==")
+		"3el6RUh6XoYJCI/ZOApyb0LLU/gSxDntVZ46R6+JNEANzfSo7/TfrzCRp5KlDo35c24r3ZOP7nnw4RqHwkMRLw==")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
fix: to resolve appimage issues in electron builder, and since we can't update electron-builder-binaries repo, we should just downgrade to the last working version of appimage