### PR TITLE
feat: Support Package Creation for OpenSUSE

### DIFF
--- a/.changeset/old-monkeys-drum.md
+++ b/.changeset/old-monkeys-drum.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": minor
+---
+
+Added support for OpenSUSE to rpm

--- a/pkg/package-format/fpm/fpm.go
+++ b/pkg/package-format/fpm/fpm.go
@@ -151,9 +151,9 @@ func getDefaultDepends(target string) []string {
 	case "rpm":
 		return []string{
 			"gtk3", /* for electron 2+ (electron 1 uses gtk2, but this old version is not supported anymore) */
-			"libnotify", "nss", "libXScrnSaver", "libXtst", "xdg-utils",
+			"libnotify", "nss", "libXScrnSaver", "(libXtst or libXtst6)", "xdg-utils",
 			"at-spi2-core", /* since 5.0.0 */
-			"libuuid",      /* since 4.0.0 */
+			"(libuuid or libuuid1)",      /* since 4.0.0 */
 		}
 
 	case "pacman":


### PR DESCRIPTION
OpenSUSE does not provide libXtst and libuuid packages, but does provide libXtst6 and libuuid1.

This PR changes the default dependencies in a way that both variants of the pacakge names are supported.