### PR TITLE
fix:  Fix the parent duplicate name issue

### DIFF
--- a/pkg/fs/findParent.go
+++ b/pkg/fs/findParent.go
@@ -1,23 +1,31 @@
 package fs
 
 import (
-	"os"
-	"path"
-	"path/filepath"
+        "os"
+        "path"
+        "path/filepath"
 )
 
 func pathExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
+        info, err := os.Stat(path)
+        if err != nil {
+                return false
+        }
+        if !info.IsDir() {
+                return false
+        }
+        packageJsonPath := filepath.Join(path, "package.json")
+        _, err = os.Stat(packageJsonPath)
+        return err == nil
 }
 
 func FindParentWithFile(cwd string, file string) string {
-	if pathExists(path.Join(cwd, file)) {
-		return cwd
-	}
-	parent := filepath.Dir(cwd)
-	if parent == cwd {
-		return ""
-	}
-	return FindParentWithFile(parent, file)
+        if pathExists(path.Join(cwd, file)) {
+                return cwd
+        }
+        parent := filepath.Dir(cwd)
+        if parent == cwd {
+                return ""
+        }
+        return FindParentWithFile(parent, file)
 }


### PR DESCRIPTION
The createHash library depends on the md5.js library, and it has a file named md5.js in its own code. This causes findParent to return createHash/md5.js, which results in not being able to locate the corresponding package.json.

https://github.com/browserify/createHash/blob/master/package.json#L35
![image](https://github.com/user-attachments/assets/fb0d05d8-800b-43ff-852f-f6353e6bbaf8)

