### PR TITLE
fix: find the real parent node module

### DIFF
--- a/.changeset/mean-dodos-smoke.md
+++ b/.changeset/mean-dodos-smoke.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": patch
+---
+
+fix: find the real parent node module

--- a/pkg/fs/findParent.go
+++ b/pkg/fs/findParent.go
@@ -21,3 +21,28 @@ func FindParentWithFile(cwd string, file string) string {
 	}
 	return FindParentWithFile(parent, file)
 }
+
+func nodeModuleExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if !info.IsDir() {
+		return false
+	}
+	packageJsonPath := filepath.Join(path, "package.json")
+	_, err = os.Stat(packageJsonPath)
+	return err == nil
+}
+
+func FindParentNodeModuleWithFile(cwd string, file string) string {
+	if nodeModuleExists(path.Join(cwd, file)) {
+		return cwd
+	}
+
+	parent := filepath.Dir(cwd)
+	if parent == cwd {
+		return ""
+	}
+	return FindParentNodeModuleWithFile(parent, file)
+}

--- a/pkg/fs/findParent.go
+++ b/pkg/fs/findParent.go
@@ -21,28 +21,3 @@ func FindParentWithFile(cwd string, file string) string {
 	}
 	return FindParentWithFile(parent, file)
 }
-
-func nodeModuleExists(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	if !info.IsDir() {
-		return false
-	}
-	packageJsonPath := filepath.Join(path, "package.json")
-	_, err = os.Stat(packageJsonPath)
-	return err == nil
-}
-
-func FindParentNodeModuleWithFile(cwd string, file string) string {
-	if nodeModuleExists(path.Join(cwd, file)) {
-		return cwd
-	}
-
-	parent := filepath.Dir(cwd)
-	if parent == cwd {
-		return ""
-	}
-	return FindParentNodeModuleWithFile(parent, file)
-}

--- a/pkg/node-modules/nodeModuleCollector.go
+++ b/pkg/node-modules/nodeModuleCollector.go
@@ -210,7 +210,7 @@ func (t *Collector) resolveDependency(parentNodeModuleDir string, name string) (
 		}
 	}
 
-	realParentNodeModuleDir := fs.FindParentWithFile(parentNodeModuleDir, name)
+	realParentNodeModuleDir := fs.FindParentNodeModuleWithFile(parentNodeModuleDir, name)
 	if realParentNodeModuleDir == "" {
 		return nil, nil
 	}

--- a/pkg/node-modules/nodeModuleCollector.go
+++ b/pkg/node-modules/nodeModuleCollector.go
@@ -211,8 +211,7 @@ func (t *Collector) resolveDependency(parentNodeModuleDir string, name string) (
 	}
 
 	realParentNodeModuleDir := fs.FindParentWithFile(parentNodeModuleDir, name)
-	info, err := os.Stat(realParentNodeModuleDir)
-	if err == nil && !info.IsDir() || realParentNodeModuleDir == "" {
+	if realParentNodeModuleDir == "" {
 		return nil, nil
 	}
 
@@ -229,6 +228,11 @@ func (t *Collector) resolveDependency(parentNodeModuleDir string, name string) (
 	}
 
 	dependencyDir := filepath.Join(realParentNodeModuleDir, name)
+	info, err := os.Stat(dependencyDir)
+	if err == nil && !info.IsDir() {
+		return nil, nil
+	}
+
 	dependency, err := readPackageJson(dependencyDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/node-modules/nodeModuleCollector.go
+++ b/pkg/node-modules/nodeModuleCollector.go
@@ -210,8 +210,9 @@ func (t *Collector) resolveDependency(parentNodeModuleDir string, name string) (
 		}
 	}
 
-	realParentNodeModuleDir := fs.FindParentNodeModuleWithFile(parentNodeModuleDir, name)
-	if realParentNodeModuleDir == "" {
+	realParentNodeModuleDir := fs.FindParentWithFile(parentNodeModuleDir, name)
+	info, err := os.Stat(realParentNodeModuleDir)
+	if err == nil && !info.IsDir() || realParentNodeModuleDir == "" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/8426

package.json
```
{
  "name": "npm-demo",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "dependencies": {
     "parse-asn1":"5.1.7"
  }
}
```

## error in macOS/linux
```
 ../../../app-builder  node-dep-tree --flatten --dir ~/Code/app-builder/pkg/node-modules/npm-demo
  ⨯ stat /root/Code/app-builder/pkg/node-modules/npm-demo/node_modules/parse-asn1/asn1.js/package.json: not a directory
github.com/develar/app-builder/pkg/node-modules.(*Collector).resolveDependency
        /root/Code/app-builder/pkg/node-modules/nodeModuleCollector.go:236
github.com/develar/app-builder/pkg/node-modules.(*Collector).processDependencies
        /root/Code/app-builder/pkg/node-modules/nodeModuleCollector.go:122
github.com/develar/app-builder/pkg/node-modules.(*Collector).readDependencyTree
        /root/Code/app-builder/pkg/node-modules/nodeModuleCollector.go:64
github.com/develar/app-builder/pkg/node-modules.(*Collector).readDependencyTree
        /root/Code/app-builder/pkg/node-modules/nodeModuleCollector.go:80
github.com/develar/app-builder/pkg/node-modules.ConfigureCommand.func1
        /root/Code/app-builder/pkg/node-modules/tree.go:41
github.com/alecthomas/kingpin.(*actionMixin).applyActions
        /root/go/pkg/mod/github.com/alecthomas/kingpin@v2.2.6+incompatible/actions.go:28
github.com/alecthomas/kingpin.(*Application).applyActions
        /root/go/pkg/mod/github.com/alecthomas/kingpin@v2.2.6+incompatible/app.go:557
github.com/alecthomas/kingpin.(*Application).execute
        /root/go/pkg/mod/github.com/alecthomas/kingpin@v2.2.6+incompatible/app.go:390
github.com/alecthomas/kingpin.(*Application).Parse
        /root/go/pkg/mod/github.com/alecthomas/kingpin@v2.2.6+incompatible/app.go:222
main.main
        /root/Code/app-builder/main.go:90
runtime.main
        /usr/local/go/src/runtime/proc.go:272
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1700
```

## error in window
```
../../../app-builder.exe node-dep-tree --flatten --dir ~/Code/app-builder/pkg/node-modules/npm-demo                                              
dir C:\Users\beyon\Code\app-builder\pkg\node-modules\npm-demo\node_modules\parse-asn1\asn1.js C:\Users\beyon\Code\app-builder\pkg\node-modules\npm-demo\node_modules\parse-asn1\asn1.js\package.json [] open C:\Users\beyon\Code\app-builder\pkg\node-modules\npm-demo\node_modules\parse-asn1\asn1.js\package.json: The system cannot find the path specified.
```

## root cause

In this PR(https://github.com/develar/app-builder/pull/89), it only searches for FindParentWithFile but doesn't verify if it's a folder or if it contains a package.json

On Windows, it returns `IsNotExist`, so it directly returns `nil`. On macOS/Linux, it returns `not a directory`, so it directly returns an error, causing the crash.
https://github.com/develar/app-builder/blob/82eeb34f03db33e54b9e54d763ae7fd7e8ad2d85/pkg/node-modules/nodeModuleCollector.go#L233