### PR TITLE
feat: move most used modues to highest level

### DIFF
--- a/pkg/node-modules/nodeModuleCollector.go
+++ b/pkg/node-modules/nodeModuleCollector.go
@@ -176,7 +176,7 @@ func (t *Collector) processHoistDependencyMap() {
 	for _, d := range t.allDependencies {
 		if e, ok := t.HoiestedDependencyMap[d.alias]; ok {
 			if e.Version != d.Version {
-				t.writeToParentConflicDependency(e)
+				t.writeToParentConflicDependency(d)
 			}
 		}
 
@@ -288,13 +288,6 @@ func correctOptionalState(isOptional bool, childDependency *Dependency) {
 // nil if already handled
 func (t *Collector) resolveDependency(parentNodeModuleDir string, name string) (*Dependency, error) {
 	dependencyNameToDependency := t.NodeModuleDirToDependencyMap[parentNodeModuleDir]
-	if dependencyNameToDependency != nil {
-		dependency := (*dependencyNameToDependency)[name]
-		if dependency != nil {
-			return dependency, nil
-		}
-	}
-
 	dependencyDir := filepath.Join(parentNodeModuleDir, name)
 	info, err := os.Stat(dependencyDir)
 	if err == nil && !info.IsDir() {

--- a/pkg/node-modules/nodeModuleCollector_test.go
+++ b/pkg/node-modules/nodeModuleCollector_test.go
@@ -34,7 +34,7 @@ func TestReadDependencyTreeByNpm(t *testing.T) {
 	g.Expect(r).To(ConsistOf([]string{
 		"js-tokens", "react", "remote", "loose-envify",
 	}))
-	remoteModule := collector.HoiestedDependencyMap["@electron/remote"]
+	remoteModule := collector.HoiestedDependencyMap["remote"]
 	g.Expect(remoteModule.alias).To(Equal("remote"))
 	g.Expect(remoteModule.Name).To(Equal("@electron/remote"))
 }
@@ -64,7 +64,7 @@ func TestReadDependencyTreeByPnpm(t *testing.T) {
 		"js-tokens", "react", "remote", "loose-envify",
 	}))
 
-	remoteModule := collector.HoiestedDependencyMap["@electron/remote"]
+	remoteModule := collector.HoiestedDependencyMap["remote"]
 	g.Expect(remoteModule.Name).To(Equal("@electron/remote"))
 	g.Expect(remoteModule.alias).To(Equal("remote"))
 	g.Expect(remoteModule.dir).To(Equal(filepath.Join(dir, "node_modules/.pnpm/@electron+remote@2.1.2_electron@31.0.0/node_modules/@electron/remote")))
@@ -101,7 +101,7 @@ func TestReadDependencyTreeForTar(t *testing.T) {
 	g.Expect(collector.HoiestedDependencyMap["tar"].dir).To(Equal(filepath.Join(dir, "node_modules/tar")))
 	g.Expect(collector.HoiestedDependencyMap["minipass"].Version).To(Equal("7.1.2"))
 	g.Expect(collector.HoiestedDependencyMap["minizlib"].Version).To(Equal("3.0.1"))
-	g.Expect(collector.HoiestedDependencyMap["tar"].conflictDependency["ansi-regex"].Version).To(Equal("5.0.1"))
+	g.Expect(collector.HoiestedDependencyMap["string-width-cjs"].conflictDependency["ansi-regex"].Version).To(Equal("5.0.1"))
 }
 
 func TestReadDependencyTreeForYarn(t *testing.T) {

--- a/pkg/node-modules/tar-demo/package-lock.json
+++ b/pkg/node-modules/tar-demo/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "tar": "^7.4.3"
+        "tar": "7.4.3"
       },
       "devDependencies": {
         "electron-builder": "25.0.5"


### PR DESCRIPTION
Moving the most frequently occurring modules to the highest level can reduce duplicate packages, thereby reducing package size.

Using the following package.json for testing, after improvement, the size of the asar can be reduced from 6.5M to 6.4M.

package.json
```
{
  "name": "electron-vue-vite",
  "version": "28.1.0",
  "main": "dist-electron/main/index.js",
  "description": "Really simple Electron + Vue + Vite boilerplate.",
  "author": "草鞋没号 <308487730@qq.com>",
  "license": "MIT",
  "private": true,
  "keywords": [
    "electron",
    "rollup",
    "vite",
    "vue3",
    "vue"
  ],
  "debug": {
    "env": {
      "VITE_DEV_SERVER_URL": "http://127.0.0.1:3344/"
    }
  },
  "type": "module",
  "scripts": {
    "dev": "vite",
    "build": "vue-tsc --noEmit && vite build && electron-builder",
    "preview": "vite preview"
  },
  "dependencies": {
    "tar": "7.4.3",
    "electron-context-menu": "4.0.4",
    "electron-updater": "6.3.6",
    "semver": "7.6.3"

  },
  "devDependencies": {
    "@vitejs/plugin-vue": "^5.0.4",
    "electron": "^29.1.1",
    "electron-builder": "25.1.2",
    "typescript": "^5.4.2",
    "vite": "^5.1.5",
    "vite-plugin-electron": "^0.28.4",
    "vite-plugin-electron-renderer": "^0.14.5",
    "vue": "^3.4.21",
    "vue-tsc": "^2.0.6"
  }
}
```
