### PR TITLE
chore: Update extract logic for using newer 7zz/7zzs/7zr.exe binaries

### DIFF
--- a/.changeset/strange-pianos-move.md
+++ b/.changeset/strange-pianos-move.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": patch
+---
+
+chore: Update extract logic for using newer 7zz/7zzs/7zr.exe binaries

--- a/pkg/download/artifactDownloader.go
+++ b/pkg/download/artifactDownloader.go
@@ -115,8 +115,15 @@ func DownloadArtifact(dirName string, url string, checksum string) (string, erro
 			return "", err
 		}
 	} else {
-		// -snld flag for https://sourceforge.net/p/sevenzip/bugs/2356/ to maintain backward compatibility between versions of 7za (old) and 7zz (new)
-		command := exec.Command(util.Get7zPath(), "x", "-snld", "-bd", archiveName, "-o"+tempUnpackDir)
+		path7zX := util.Get7zPath()
+		var args []string
+		args = append(args, "x")
+		if !strings.HasSuffix(path7zX, "7za") {
+			// -snld flag for https://sourceforge.net/p/sevenzip/bugs/2356/ to maintain backward compatibility between versions of 7za (old) and 7zz/7zzs/7zr.exe (new)
+			args = append(args, "-snld")
+		}
+		args = append(args, "-bd", archiveName, "-o"+tempUnpackDir)
+		command := exec.Command(path7zX, args...)
 		command.Dir = cacheDir
 		_, err := util.Execute(command)
 		if err != nil {

--- a/pkg/download/artifactDownloader.go
+++ b/pkg/download/artifactDownloader.go
@@ -12,7 +12,7 @@ import (
 	"github.com/develar/app-builder/pkg/log"
 	"github.com/develar/app-builder/pkg/util"
 	"github.com/develar/errors"
-	"github.com/develar/go-fs-util"
+	fsutil "github.com/develar/go-fs-util"
 	"github.com/mitchellh/go-homedir"
 	"go.uber.org/zap"
 )
@@ -115,7 +115,8 @@ func DownloadArtifact(dirName string, url string, checksum string) (string, erro
 			return "", err
 		}
 	} else {
-		command := exec.Command(util.Get7zPath(), "x", "-bd", archiveName, "-o"+tempUnpackDir)
+		// -snld flag for https://sourceforge.net/p/sevenzip/bugs/2356/ to maintain backward compatibility between versions of 7za (old) and 7zz (new)
+		command := exec.Command(util.Get7zPath(), "x", "-snld", "-bd", archiveName, "-o"+tempUnpackDir)
 		command.Dir = cacheDir
 		_, err := util.Execute(command)
 		if err != nil {


### PR DESCRIPTION
Conditionally adds `-snld` flag based on detecting SZA binary path to have suffix `7za`.
Maintains backward compatibility of app-builder-bin's extract artifact logic between versions of 7za (old) and 7zz/7zzs/7zr.exe (new)
Ref: https://sourceforge.net/p/sevenzip/bugs/2356/

Tested with artifacts in related PR https://github.com/develar/7zip-bin/pull/27