### PR TITLE
fix: handle the table of content resource type correctly

### DIFF
--- a/.changeset/curly-parents-peel.md
+++ b/.changeset/curly-parents-peel.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": patch
+---
+
+fix: handle the table of content resource type correctly

--- a/pkg/icons/icns.go
+++ b/pkg/icons/icns.go
@@ -168,7 +168,7 @@ func ReadIcns(reader *bufio.Reader) (map[string]SubImage, error) {
 		imageDataLength := int(icon.Length) - 8
 
 		osType := string(icon.Type[:])
-		if osType != "info" && osType != "TOC" && osType != "icnV" && osType != "name" {
+		if osType != "info" && osType != "TOC " && osType != "icnV" && osType != "name" {
 			typeToImage[osType] = SubImage{
 				Offset: offset,
 				Length: imageDataLength,


### PR DESCRIPTION
All ICNS resource type entries are made of a type and a length. The resource type is always a 4 byte string - if it's shorter than 4 bytes, it is filled with space (0x20) characters. This is also the case for the 'TOC ' resource type, so add the missing space character.