### PR TITLE
feat: adding env var for "dirname" to mirror the logic in electron-builder

### DIFF
--- a/.changeset/soft-doors-play.md
+++ b/.changeset/soft-doors-play.md
@@ -1,0 +1,5 @@
+---
+"app-builder-bin": minor
+---
+
+feat: adding env var for "dirname" to mirror the logic in electron-builder

--- a/pkg/download/tool.go
+++ b/pkg/download/tool.go
@@ -60,7 +60,7 @@ func DownloadWinCodeSign() (string, error) {
 
 func downloadFromGithub(name string, version string, checksum string) (string, error) {
 	id := name + "-" + version
-	return DownloadArtifact(id, GetGithubBaseUrl()+id+"/"+id+".7z", checksum)
+	return DownloadArtifact(id, GetGithubBaseUrl()+GetGithubReleaseUrl(id)+"/"+id+".7z", checksum)
 }
 
 func GetGithubBaseUrl() string {
@@ -76,6 +76,23 @@ func GetGithubBaseUrl() string {
 	}
 	if len(v) == 0 {
 		v = "https://github.com/electron-userland/electron-builder-binaries/releases/download/"
+	}
+	return v
+}
+
+func GetGithubReleaseUrl(defaultName string) string {
+	v := os.Getenv("NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR")
+	if len(v) == 0 {
+		v = os.Getenv("npm_config_electron_builder_binaries_custom_dir")
+	}
+	if len(v) == 0 {
+		v = os.Getenv("npm_package_config_electron_builder_binaries_custom_dir")
+	}
+	if len(v) == 0 {
+		v = os.Getenv("ELECTRON_BUILDER_BINARIES_CUSTOM_DIR")
+	}
+	if len(v) == 0 {
+		v = defaultName
 	}
 	return v
 }


### PR DESCRIPTION
Current logic already uses env var `ELECTRON_BUILDER_BINARIES_MIRROR`
https://github.com/develar/app-builder/blob/580c34f2e19347061bc2243fa6ab6e57e9bbd2a6/pkg/download/tool.go#L61-L81

But it does not allow customization of the dir (both being the `id` of the asset)
https://github.com/develar/app-builder/blob/580c34f2e19347061bc2243fa6ab6e57e9bbd2a6/pkg/download/tool.go#L63

This implementation now will properly mirror the (duplicated) logic in electron-builder for app-builder-bin downloading
https://github.com/electron-userland/electron-builder/blob/3d65267a6c53ca824f70e5b0f5d8f4ba8be38237/packages/app-builder-lib/src/binDownload.ts#L25-L38